### PR TITLE
Fix inconsistent colors between Windows and Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -682,7 +682,7 @@ dependencies = [
 
 [[package]]
 name = "heat-wgpu"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bytemuck",
  "env_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "heat-wgpu"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -52,6 +52,10 @@ cargo run --release
 - LeVeque, R. J. (2007). *Finite difference methods for ordinary and partial differential equations: steady-state and time-dependent problems. Society for Industrial and Applied Mathematics*.
 - Shewchuk, J. R. (1994). [*An introduction to the conjugate gradient method without the agonizing pain*](https://www.cs.cmu.edu/~quake-papers/painless-conjugate-gradient.pdf).
 - Bell, N., & Garland, M. (2008). *Efficient sparse matrix-vector multiplication on CUDA (Vol. 2, No. 5). Nvidia Technical Report NVR-2008-004, Nvidia Corporation*.
+- GPU Gems 2: Programming Techniques for High-Performance Graphics and General-Purpose Computation. 2005. Addison-Wesley Professional.
+  - Specifically [*Chapter 44: A GPU Framework for Solving Systems of Linear Equations*](https://developer.nvidia.com/gpugems/gpugems2/part-vi-simulation-and-numerical-algorithms/chapter-44-gpu-framework-solving), which also cites the following papers:
+    - Bolz, J., I. Farmer, E. Grinspun, and P. Schröder. 2003. "Sparse Matrix Solvers on the GPU: Conjugate Gradients and Multigrid." *ACM Transactions on Graphics (Proceedings of SIGGRAPH 2003)* 22(3), pp. 917–924.
+    - Krüger, Jens, and Rüdiger Westermann. 2003. "Linear Algebra Operators for GPU Implementation of Numerical Algorithms." *ACM Transactions on Graphics (Proceedings of SIGGRAPH 2003)* 22(3), pp. 908–916.
 - Harris, M. (2007). *Optimizing parallel reduction in CUDA. Nvidia developer technology, 2*(4), 70.
 - Mikhailov, A. (2019). [Turbo, An Improved Rainbow Colormap for Visualization](https://ai.googleblog.com/2019/08/turbo-improved-rainbow-colormap-for.html).
 - [WebGPU specification](https://gpuweb.github.io/gpuweb/).

--- a/README.md
+++ b/README.md
@@ -53,4 +53,5 @@ cargo run --release
 - Shewchuk, J. R. (1994). [*An introduction to the conjugate gradient method without the agonizing pain*](https://www.cs.cmu.edu/~quake-papers/painless-conjugate-gradient.pdf).
 - Bell, N., & Garland, M. (2008). *Efficient sparse matrix-vector multiplication on CUDA (Vol. 2, No. 5). Nvidia Technical Report NVR-2008-004, Nvidia Corporation*.
 - Harris, M. (2007). *Optimizing parallel reduction in CUDA. Nvidia developer technology, 2*(4), 70.
+- Mikhailov, A. (2019). [Turbo, An Improved Rainbow Colormap for Visualization](https://ai.googleblog.com/2019/08/turbo-improved-rainbow-colormap-for.html).
 - [WebGPU specification](https://gpuweb.github.io/gpuweb/).

--- a/src/app.rs
+++ b/src/app.rs
@@ -61,6 +61,7 @@ impl App {
             .await
             .unwrap();
         println!("Adapter: {:?}", adapter.get_info());
+        println!("Surface: {:?}", surface.get_capabilities(&adapter));
         //device and queue
         let (device, queue) = adapter
             .request_device(
@@ -83,8 +84,10 @@ impl App {
             .get_default_config(&adapter, size.width, size.height)
             .expect("Surface isn't supported by the adapter.");
         config.present_mode = wgpu::PresentMode::Fifo;
+        config.format = wgpu::TextureFormat::Bgra8Unorm;
         let surface_view_format = config.format.add_srgb_suffix();
         config.view_formats.push(surface_view_format);
+        println!("Config: {:?}", config);
         surface.configure(&device, &config);
 
         // ------ GPU Compute config ------

--- a/src/shaders/render.wgsl
+++ b/src/shaders/render.wgsl
@@ -36,6 +36,8 @@ fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
 
 // Turbo colormap (polynomial approximation)
 // reference: https://ai.googleblog.com/2019/08/turbo-improved-rainbow-colormap-for.html
+// Original LUT: https://gist.github.com/mikhailov-work/ee72ba4191942acecc03fe6da94fc73f
+// Authors: Anton Mikhailov (mikhailov@google.com), Ruofei Du (ruofei@google.com)
 fn TurboColormap(x: f32) -> vec3<f32> {
   let kRedVec4: vec4<f32> = vec4<f32>(0.13572138, 4.61539260, -42.66032258, 132.13108234);
   let kGreenVec4: vec4<f32> = vec4<f32>(0.09140261, 2.19418839, 4.84296658, -14.18503333);


### PR DESCRIPTION
fixes #2.

As per https://github.com/gfx-rs/wgpu/wiki/Texture-Color-Formats-and-Srgb-conversions:


> Lets walk our way up the color pipeline. The OS assumes that the bits you are sending to the screen are monitor referred and in the srgb space (unless otherwise specified). It will interpret the bits this way no matter what.
> 
> - If you write / shade to a texture which is in the format of **Unorm** it will take the output of your shader and do a float -> int conversion and that's it (Unorm floats are written as ints under the hood though you don't need to worry about this). 
> 
> This means that if you're using this **Unorm** texture as a surface, *the floats you are writing from your shader need to be **monitor referred** (ie numbers that the os can safely assume are already in sRGB space).*
> 
> - If you write / shade to a texture which is in the format of **UnormSrgb** it will take the output of your shader and then apply the sRGB OETF to it, then afterwards do the float -> int conversion to store the data. 
> 
> This means that if you're using this **UnormSrgb** texture as a surface, *the floats you are writing from your shader need to be **scene referred**, as the gpu will do the conversion to monitor referred as part of the write!*
> 
> The inverse happens when you read from a texture:
> - a **Unorm** texture just does int -> float on read.
> - a **UnormSrgb** texture applies the sRGB EOTF to do monitor -> scene and then does the int -> float write.
> 

The problem is that Windows, by default, had the surface configured with `Bgra8UnormSrgb` as it's [format](https://docs.rs/wgpu-types/latest/wgpu_types/struct.SurfaceConfiguration.html). This does not correspond to the output of the render pipeline, which takes the f32 value from the texture storage buffer and *already* converts it to a value in sRGB space through the [turbo](https://ai.googleblog.com/2019/08/turbo-improved-rainbow-colormap-for.html) colormap. Thus, to solve the issue, we just remove the sRGB suffix (which was responsible for transforming from *scene referred* to *monitor referred*, as per the quote), **because we already are in monitor reffered space**.